### PR TITLE
Fix for Dev Containers CLI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@
 ARG RUBY_VERSION=3.3.4
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
+USER vscode
+
 # Ensure binding is always 0.0.0.0
 # Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
 ENV BINDING="0.0.0.0"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,7 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=3.3.4
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
+
+# Ensure binding is always 0.0.0.0
+# Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
+ENV BINDING="0.0.0.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,8 +29,6 @@
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root",
 
-  "containerUser": "vscode",
-
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "bin/setup --skip-server"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,7 @@
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root",
 
+  "containerUser": "vscode",
 
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "bin/setup --skip-server"


### PR DESCRIPTION
Adding `"containerUser": "vscode"` to `.devcontainer/devcontainer.json` resolves the issue by ensuring all commands run as the `vscode` user, thus preventing permission errors caused by commands running as `root`.

This workaround remains applicable while the related Podman issue is open in [devcontainers CLI issue #708](https://github.com/devcontainers/cli/issues/708).

### Steps to reproduce with CLI

- Start Dev Container

```bash
> devcontainer --workspace-folder . up
 => [rails-app] resolving provenance for metadata file                                                                                                                                                           0.0s
[17101 ms] Start: Run: docker-compose --project-name rails8-devcontainer-enhancements_devcontainer -f /Users/viktorianer/Documents/projects/rails8-devcontainer-enhancements/.devcontainer/compose.yaml -f /var/folders/vv/m5djvkbs6t1fr96k4l3cp66w0000gn/T/devcontainercli/docker-compose/docker-compose.devcontainer.build-1727630786754.yml -f /var/folders/vv/m5djvkbs6t1fr96k4l3cp66w0000gn/T/devcontainercli/docker-compose/docker-compose.devcontainer.containerFeatures-1727630801496.yml up -d
[+] Running 3/3
 ✔ Container rails8-devcontainer-enhancements_devcontainer-selenium-1   Started                                                                                                                                  0.1s
 ✔ Container rails8-devcontainer-enhancements_devcontainer-postgres-1   Started                                                                                                                                  0.1s
 ✔ Container rails8-devcontainer-enhancements_devcontainer-rails-app-1  Started                                                                                                                                  0.2s
{"outcome":"success","containerId":"c067fc3a1993424ed84c586be3d354d5e79069a82e7ee70b0b0263d31d9183b6","composeProjectName":"rails8-devcontainer-enhancements_devcontainer","remoteUser":"vscode","remoteWorkspaceFolder":"/workspaces/rails8-devcontainer-enhancements"}
```

- You'll notice that `"postCreateCommand": "bin/setup --skip-server"` is not executed.

### Expected behavior with CLI

- The `postCreateCommand` should run, installing dependencies and setting up the Rails app.

```bash
[+] Running 3/3
...
Running the postCreateCommand from devcontainer.json...

== Installing dependencies ==
...
```

- The Rails app should be accessible on port 3000.

### Actual behavior with CLI

- Rails 8 is not installed, and the Rails app is not accessible on port 3000.

```bash
> devcontainer exec --workspace-folder . zsh
$ ruby -v
$ ruby 3.3.4 (2024-07-09 revision be1089c8ec) [aarch64-linux]

$ rails -v
$ zsh: command not found: rails
```

- Additionally, the default setup blocks access to services on port 3000 and other provided ports.