### PR TITLE
Fix for Docker Compose

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,9 @@
 ARG RUBY_VERSION=3.3.4
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
+# Set the app working directory
+WORKDIR /app
+
 # Ensure binding is always 0.0.0.0
 # Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
 ENV BINDING="0.0.0.0"

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -3,6 +3,7 @@ name: "rails8_devcontainer_enhancements"
 services:
   rails-app:
     image: rails8_devcontainer_enhancements_rails_app
+    user: "vscode"
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -8,6 +8,7 @@ services:
 
     volumes:
     - ../..:/workspaces:cached
+    - bundle-data:/home/vscode/.rbenv
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -37,4 +38,5 @@ services:
         POSTGRES_PASSWORD: postgres
 
 volumes:
+  bundle-data:
   postgres-data:

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -2,6 +2,7 @@ name: "rails8_devcontainer_enhancements"
 
 services:
   rails-app:
+    image: rails8_devcontainer_enhancements_rails_app
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
@@ -39,4 +40,6 @@ services:
 
 volumes:
   bundle-data:
+    name: rails8_devcontainer_enhancements_bundle_data
   postgres-data:
+    name: rails8_devcontainer_enhancements_postgres_data

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -9,7 +9,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
 
     volumes:
-    - ../..:/workspaces:cached
+    - ../:/app:cached
     - bundle-data:/home/vscode/.rbenv
 
     # Overrides default command so things don't shut down after the process ends.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "rails8_devcontainer_enhancements",
   "dockerComposeFile": "compose.yaml",
   "service": "rails-app",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/app",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {


### PR DESCRIPTION
Enable running services in Docker without requiring Dev Containers.

**Current Status:** This is not yet fully functional, as the `ruby` installed by `rbenv` is not available outside of an interactive shell.

We've added a custom image name for the `rails-app` service, adjusted the volume setup, changed the working directory to `/app`, and moved `containerEnv` settings into `.devcontainer/compose.yaml`. This allows usage of `docker compose up -d`.

Additionally, we introduced a new volume for bundler dependencies. Note that the feature from https://github.com/rails/devcontainer/pull/48 is incompatible with `docker compose`.

To use `docker compose up -d` without explicitly specifying `.devcontainer/compose.yaml`, add an `.env` file containing `COMPOSE_FILE=.devcontainer/compose.yaml`. There currently seems to be no alternative solution.

## Steps to reproduce with Docker Compose

- Start the project using `docker compose` commands.
- Observe the failure with the error `no configuration file provided`.

## Expected behavior with Docker Compose

- Running `docker compose up -d rails-app` should start the `rails-app` container along with any `depends_on` services.
- No rebuild should be required if project images were previously built using Dev Container CLI.

```bash
> docker compose -f .devcontainer/compose.yaml up -d rails-app
[+] Running 3/3
 ✔ Container rails8_devcontainer_enhancements_devcontainer-selenium-1   Started                                                                                                                              0.1s
 ✔ Container rails8_devcontainer_enhancements_devcontainer-postgres-1   Started                                                                                                                              0.1s
 ✔ Container rails8_devcontainer_enhancements_devcontainer-rails-app-1  Started

...
> docker compose -f .devcontainer/compose.yaml exec rails-app bin/rails test
yarn install v1.22.22
...
Finished in 0.338074s, 20.7056 runs/s, 20.7056 assertions/s.
7 runs, 7 assertions, 0 failures, 0 errors, 0 skips
```

## Actual behavior with Docker Compose

- Running `docker compose up -d rails-app` fails with the error `no configuration file provided`.

```bash
> docker compose up -d rails-app
$ no configuration file provided: not found
$ Error: executing /usr/local/bin/docker-compose up -d rails-app: exit status 14
```