### PR TITLE
Adjust update schedule and refine versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,60 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
+  groups:
+    bundler-patch:
+      patterns:
+        - "*"
+      update-types:
+        - patch
+    bundler-minor:
+      patterns:
+        - "*"
+      update-types:
+        - minor
+    bundler-major:
+      applies-to: security-updates
+      patterns:
+        - "*"
+      update-types:
+        - major
+  ignore:
+    - dependency-name: "rails"
+      update-types:
+        - version-update:semver-major
+        - version-update:semver-minor
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
+  groups:
+    npm-patch:
+      patterns:
+        - "*"
+      update-types:
+        - patch
+    npm-minor:
+      patterns:
+        - "*"
+      update-types:
+        - minor
+    npm-major:
+      applies-to: security-updates
+      patterns:
+        - "*"
+      update-types:
+        - major
+  ignore:
+    - dependency-name: "bootstrap"
+      update-types:
+        - version-update:semver-major
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot is creating frequent and unnecessary pull requests, causing noise and difficulty in managing updates, especially with minor and patch version bumps for Bundler and npm.

## Steps to reproduce with Dependabot

1. Create a new Rails project, configured with Dependabot with daily updates for Bundler, npm, and GitHub Actions.
2. Dependabot creates pull requests for each version bump, including non-critical updates.

## Expected behavior with Dependabot

Dependabot should group updates by patch, minor, and major versions. Major updates should be limited to security fixes, and updates for certain dependencies like Rails and Bootstrap should be excluded to prevent disruption. PR frequency should be reduced to weekly.

## Actual behavior with Dependabot

Dependabot creates daily pull requests for all version bumps, regardless of severity, and does not differentiate between security updates and regular updates, leading to excessive PRs.