### PR TITLE
Improve installing bundler dependencies

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -8,6 +8,7 @@ services:
 
     volumes:
     - ../..:/workspaces:cached
+    - bundle-data:/home/vscode/.rbenv
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -37,4 +38,5 @@ services:
         POSTGRES_PASSWORD: postgres
 
 volumes:
+  bundle-data:
   postgres-data:

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -8,7 +8,7 @@ services:
 
     volumes:
     - ../..:/workspaces:cached
-    - bundle-data:/home/vscode/.rbenv
+    - rbenv-data:/home/vscode/.rbenv
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -38,5 +38,5 @@ services:
         POSTGRES_PASSWORD: postgres
 
 volumes:
-  bundle-data:
+  rbenv-data:
   postgres-data:


### PR DESCRIPTION
A new volume has been introduced for bundler dependencies. While PR https://github.com/rails/devcontainer/pull/48 addresses the same issue, this implementation is simpler.

## Steps to reproduce with Reinstalling Bundler Dependencies

- Run `devcontainer --workspace-folder . up` multiple times.

## Expected behavior with Reinstalling Bundler Dependencies

- Stop the running Docker project.
- Run `devcontainer --workspace-folder . up`.
- Bundler should recognize that dependencies are already installed and not reinstall them.

```
...
== Installing dependencies ==
The Gemfile's dependencies are satisfied
yarn install v1.22.22
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.56s.
...
```

## Actual behavior with Reinstalling Bundler Dependencies

- Stop the running Docker project.
- Run `devcontainer --workspace-folder . up`.
- Bundler reinstalls dependencies that were previously installed.

```bash
> devcontainer --workspace-folder . up
...
== Installing dependencies ==
https://github.com/rails/rails.git (at main@3ebff69) is not yet checked out. Run `bundle install` first.
...
Fetching gem metadata from https://rubygems.org/.
...
Fetching https://github.com/rails/rails.git
Fetching rake 13.2.1
Installing rake 13.2.1
...
Bundle complete! 23 Gemfile dependencies, 121 gems now installed.
...
yarn install v1.22.22
[1/4] Resolving packages...
success Already up-to-date.
...
```